### PR TITLE
Add command `update`

### DIFF
--- a/lib/pod/cli.rb
+++ b/lib/pod/cli.rb
@@ -90,12 +90,18 @@ module Pod
     end
 
     desc "sync PODCAST_ID", "Sync the podcast."
-    # TODO
-    # method_option :feed, type: :string, default: '', desc: "The feed that should be used."
     def sync(podcast_id)
       result = Pod::Commands::Sync.call(podcast_id)
 
       puts Pod::Outputs::Text::Sync.call(result)
+    end
+
+    desc "update PODCAST_ID", "Update the podcast attributes."
+    method_option :feed, type: :string, default: "", desc: "Define the podcast feed."
+    def update(podcast_id)
+      result = Pod::Commands::Update.call(podcast_id, options)
+
+      puts Pod::Outputs::Text::Update.call(result)
     end
   end
 end

--- a/lib/pod/commands.rb
+++ b/lib/pod/commands.rb
@@ -10,6 +10,7 @@ require_relative "commands/archive"
 require_relative "commands/dearchive"
 require_relative "commands/delete"
 require_relative "commands/sync"
+require_relative "commands/update"
 
 module Pod
   module Commands; end

--- a/lib/pod/commands/update.rb
+++ b/lib/pod/commands/update.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Pod
+  module Commands
+    class Update < Base
+      def call(podcast_id, options = {})
+        parsed_options = parse_options(options)
+        return build_failure_response(details: :invalid_options) if parsed_options.empty?
+
+        db = Pod::Storage::SQL.new(db: pod_db_dir)
+        if db.query("select id from podcasts where id = #{podcast_id}").empty?
+          return build_failure_response(details: :not_found)
+        end
+
+        sql_code = <<~SQL
+          update podcasts
+          set feed = '#{options["feed"]}'
+          where id = #{podcast_id};
+        SQL
+        db.execute(sql_code)
+        build_success_response(details: :podcast_updated)
+      end
+    end
+  end
+end

--- a/lib/pod/outputs/text.rb
+++ b/lib/pod/outputs/text.rb
@@ -10,6 +10,7 @@ require_relative "text/archive"
 require_relative "text/dearchive"
 require_relative "text/delete"
 require_relative "text/sync"
+require_relative "text/update"
 
 module Pod
   module Outputs

--- a/lib/pod/outputs/text/update.rb
+++ b/lib/pod/outputs/text/update.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Pod
+  module Outputs
+    module Text
+      class Update < ::Pod::Outputs::Base
+        def call
+          case @context[:details]
+          when :podcast_updated
+            <<~OUTPUT
+              Podcast successfully updated!
+            OUTPUT
+          when :invalid_options
+            <<~OUTPUT
+              Invalid options. Check the documentation `pod help update`.
+            OUTPUT
+          when :not_found
+            <<~OUTPUT
+              Podcast not found.
+            OUTPUT
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pod/cli_spec.rb
+++ b/spec/pod/cli_spec.rb
@@ -254,4 +254,16 @@ RSpec.describe Pod::CLI do
       expect(result).to eq(expected_output.chomp)
     end
   end
+
+  describe "update command", :init_pod, :populate_db do
+    it "updated the podcast" do
+      expected_output = <<~OUTPUT
+        Podcast successfully updated!
+      OUTPUT
+
+      result = TestHelpers::CLI.run_cmd("pod update 1 --feed=https://www.newfeed.com")
+
+      expect(result).to eq(expected_output.chomp)
+    end
+  end
 end

--- a/spec/pod/commands/update_spec.rb
+++ b/spec/pod/commands/update_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../../support/test_helpers"
+
+RSpec.describe Pod::Commands::Update do
+  describe "#call", :init_pod do
+    context "when valid options are received and the podcast exists", :populate_db do
+      it "returns a success response and updates the podcast" do
+        db = Pod::Storage::SQL.new(db: TestHelpers::Path.db_dir)
+        before_podcast = db.query("select * from podcasts", Pod::Entities::Podcast).first
+
+        result = described_class.call(1, {"feed" => "https://www.newfeed.com"})
+
+        expect(result[:status]).to eq(:success)
+        expect(result[:details]).to eq(:podcast_updated)
+        after_podcast = db.query("select * from podcasts", Pod::Entities::Podcast).first
+        expect(before_podcast.id).to eq(after_podcast.id)
+        expect(before_podcast.name).to eq(after_podcast.name)
+        expect(before_podcast.description).to eq(after_podcast.description)
+        expect(before_podcast.feed).to_not eq(after_podcast.feed)
+        expect(after_podcast.feed).to eq("https://www.newfeed.com")
+        expect(before_podcast.website).to eq(after_podcast.website)
+      end
+    end
+
+    context "when invalid options are received", :populate_db do
+      it "returns a failure response and does not updates the podcast" do
+        db = Pod::Storage::SQL.new(db: TestHelpers::Path.db_dir)
+        before_podcast = db.query("select * from podcasts", Pod::Entities::Podcast).first
+
+        result = described_class.call(1, {"feed" => ""})
+
+        expect(result[:status]).to eq(:failure)
+        expect(result[:details]).to eq(:invalid_options)
+        after_podcast = db.query("select * from podcasts", Pod::Entities::Podcast).first
+        expect(before_podcast.id).to eq(after_podcast.id)
+        expect(before_podcast.name).to eq(after_podcast.name)
+        expect(before_podcast.description).to eq(after_podcast.description)
+        expect(before_podcast.feed).to eq(after_podcast.feed)
+        expect(before_podcast.website).to eq(after_podcast.website)
+      end
+    end
+
+    context "when the podcast is not found" do
+      it "returns a failure response and does not updates the podcast" do
+        result = described_class.call(1, {"feed" => "https://www.newfeed.com"})
+
+        expect(result[:status]).to eq(:failure)
+        expect(result[:details]).to eq(:not_found)
+      end
+    end
+  end
+end

--- a/spec/pod/outputs/text/update_spec.rb
+++ b/spec/pod/outputs/text/update_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Pod::Outputs::Text::Update do
+  describe "#call" do
+    context "when podcast was updated" do
+      it "generates the correct message" do
+        response = described_class.new(status: :success, details: :podcast_updated)
+        expected_output = <<~OUTPUT
+          Podcast successfully updated!
+        OUTPUT
+
+        msg = response.call
+
+        expect(msg).to eq(expected_output)
+      end
+    end
+
+    context "when invalid options were passed" do
+      it "generates the correct message" do
+        response = described_class.new(status: :failure, details: :invalid_options)
+        expected_output = <<~OUTPUT
+          Invalid options. Check the documentation `pod help update`.
+        OUTPUT
+
+        msg = response.call
+
+        expect(msg).to eq(expected_output)
+      end
+    end
+
+    context "when the podcast were not found" do
+      it "generates the correct message" do
+        response = described_class.new(status: :failure, details: :not_found)
+        expected_output = <<~OUTPUT
+          Podcast not found.
+        OUTPUT
+
+        msg = response.call
+
+        expect(msg).to eq(expected_output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This command can be used to update the podcast attributes. This initial implementation only supports the `feed` attribute.